### PR TITLE
Initialize shared modal component

### DIFF
--- a/src/components/related/Card.jsx
+++ b/src/components/related/Card.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { getProductCard } from './api.js';
+import useModal from '../shared/useModal.js';
+import Modal from '../shared/Modal.jsx';
 
 const CardContainer = styled.div`
   position: relative;
@@ -28,6 +30,8 @@ const Button = styled.button`
 export default function Card({ id }) {
   const [product, setProduct] = useState({});
 
+  const { visible, toggle } = useModal();
+
   // get product info based on the id prop
   useEffect(() => {
     getProductCard(id).then((res) => setProduct(res));
@@ -39,7 +43,11 @@ export default function Card({ id }) {
       <Img src={product.image ? product.image : 'https://media.istockphoto.com/id/1281804798/photo/very-closeup-view-of-amazing-domestic-pet-in-mirror-round-fashion-sunglasses-is-isolated-on.jpg?b=1&s=170667a&w=0&k=20&c=4CLWHzcFeku9olx0np2htie2cOdxWamO-6lJc-Co8Vc='} alt="" />
 
       {/* functionality will be determined by which list the card is in */}
-      <Button type="button">?</Button>
+      <Button type="button" onClick={toggle}>?</Button>
+      <Modal visible={visible} toggle={toggle}>
+        {/* Modal renders its children, so place content between tags */}
+        <h1>Card modal!</h1>
+      </Modal>
       <h4>{product.category}</h4>
       <h3>{product.name}</h3>
       <p>

--- a/src/components/shared/Modal.jsx
+++ b/src/components/shared/Modal.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import styled from 'styled-components';
+
+// Overlay to dim content on the DOM
+const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1040;
+  width: 100vw;
+  height: 100vh;
+  background-color: #000;
+  opacity: .5;
+`;
+
+// Wrapper for modal, z-index is higher than Overlay so it displays on top of it
+const Wrapper = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1050;
+  width: 100%;
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+  outline: 0;
+`;
+
+// we can adjust this stuff as needed
+const ModalContainer = styled.div`
+  z-index: 100;
+  background: white;
+  margin: 1.75rem auto;
+  max-width: 800px;
+  padding: 2rem;
+`;
+
+// place button on the right, can be styled better later
+const Header = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+export default function Modal({ visible, toggle, children }) {
+  // only render if visible is true
+  if (visible) {
+    // prevent scrolling
+    document.body.style.overflow = 'hidden';
+    // eslint-disable-next-line function-paren-newline
+    return ReactDOM.createPortal(
+      <>
+        <Overlay />
+        <Wrapper aria-modal aria-hidden tabIndex={-1} role="dialog">
+          <ModalContainer>
+            <Header>
+              <button type="button" className="modal-close-button" data-dismiss="modal" aria-label="Close" onClick={toggle}>
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </Header>
+            {/* Render children onto the modal */}
+            {children}
+          </ModalContainer>
+        </Wrapper>
+      </>, document.body);
+  }
+
+  // re-enable scrolling when modal is hidden
+  document.body.style.overflow = 'unset';
+}

--- a/src/components/shared/useModal.js
+++ b/src/components/shared/useModal.js
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+
+// custom modal hook
+export default function useModal() {
+  const [visible, setVisible] = useState(false);
+
+  const toggle = () => {
+    setVisible(!visible);
+  };
+
+  return {
+    visible,
+    toggle,
+  };
+}


### PR DESCRIPTION
This PR adds a few things...

First is the `useModal` custom hook. I think it can be thought of as a state that stores whether a modal should be rendered or not, since that's whats going on under the hood. Whenever you want to use a modal in a component, use the `useModal` hook and pass the returned variables on as props to the actual modal, so that both the current component and the modal component can toggle whether the modal is active or not.

Next is the actual `Modal` component. Like mentioned above, it takes in the values returned by the `useModal` hook to tell whether the modal should be rendered and to unmount the modal from the DOM. It also takes a `children` prop. Unlike other props, the `children` prop represents anything between two modal tags. For example:
```js
<Modal>
  <p>Child 1</p>
  <p>Child 2</p>
</Modal>
```
Here, the `children` prop represents the two `<p>` tags. This lets us all reuse the `Modal` component, since we can pass along components of our own instead of having to write a new modal for each of our widgets. We will definitely need to come back to refactor the styling and add accessibility stuff, but I think for now it's a good base to work off of.

Lastly is the changes to `Card.jsx`. I just wanted to use the modal component in an easy way with custom children so I had a base to work off of when implementing the table modal for the related items. When a card gets clicked, a modal pops up with the text "Card modal!". 

![image](https://user-images.githubusercontent.com/25358856/205947207-29e94039-c890-45e8-9522-eb5bec97ad6f.png)
