### PR TITLE
Allow user to see table modal that compares products

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,10 @@ const Header = styled.header`
   background: #313457;
   color: white;
   width: 100vw;
+  max-width: 100%;
+  font-size: 1.5em;
+  padding: 0.5em;
+  box-sizing: border-box;
 `;
 
 function App() {

--- a/src/components/related/Card.jsx
+++ b/src/components/related/Card.jsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { getProductCard } from './api.js';
 import useModal from '../shared/useModal.js';
 import Modal from '../shared/Modal.jsx';
+import Table from './Table.jsx';
 
 const CardContainer = styled.div`
   position: relative;
@@ -27,7 +28,7 @@ const Button = styled.button`
   right: 10px;
 `;
 
-export default function Card({ id }) {
+export default function Card({ id, parent }) {
   const [product, setProduct] = useState({});
 
   const { visible, toggle } = useModal();
@@ -46,7 +47,7 @@ export default function Card({ id }) {
       <Button type="button" onClick={toggle}>?</Button>
       <Modal visible={visible} toggle={toggle}>
         {/* Modal renders its children, so place content between tags */}
-        <h1>Card modal!</h1>
+        <Table currentId={parent} target={product} />
       </Modal>
       <h4>{product.category}</h4>
       <h3>{product.name}</h3>

--- a/src/components/related/Card.jsx
+++ b/src/components/related/Card.jsx
@@ -20,8 +20,8 @@ const Img = styled.img`
 `;
 
 const Button = styled.button`
-  width: 20px;
-  height: 20px;
+  width: 1.5rem;
+  height: 1.5rem;
   border-radius: 50%;
   position: absolute;
   top: 10px;
@@ -44,7 +44,7 @@ export default function Card({ id, parent }) {
       <Img src={product.image ? product.image : 'https://media.istockphoto.com/id/1281804798/photo/very-closeup-view-of-amazing-domestic-pet-in-mirror-round-fashion-sunglasses-is-isolated-on.jpg?b=1&s=170667a&w=0&k=20&c=4CLWHzcFeku9olx0np2htie2cOdxWamO-6lJc-Co8Vc='} alt="" />
 
       {/* functionality will be determined by which list the card is in */}
-      <Button type="button" onClick={toggle}>?</Button>
+      <Button type="button" onClick={toggle}>☆</Button>
       <Modal visible={visible} toggle={toggle}>
         {/* Modal renders its children, so place content between tags */}
         <Table currentId={parent} target={product} />

--- a/src/components/related/RelatedList.jsx
+++ b/src/components/related/RelatedList.jsx
@@ -23,7 +23,7 @@ export default function RelatedList() {
       <div className="related">
         <h1>Related Items:</h1>
         <ListContainer>
-          {related.map((product) => <Card key={product} id={product} />)}
+          {related.map((product) => <Card key={product} id={product} parent={37311} />)}
         </ListContainer>
       </div>
       <div className="outfit">

--- a/src/components/related/Table.jsx
+++ b/src/components/related/Table.jsx
@@ -1,0 +1,58 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { getProductCard } from './api.js';
+
+// center table within modal
+const TableContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export default function Table({ currentId, target }) {
+  const [current, setCurrent] = useState({});
+  const [features, setFeatures] = useState({});
+
+  // can be refactored later, this data should be stored somewhere already...
+  useEffect(() => {
+    const obj = {};
+    getProductCard(currentId).then((product) => {
+      // GET data for current item, push characteristics into obj
+      product.features.forEach((f) => {
+        if (obj[f.feature] === undefined) obj[f.feature] = ['', ''];
+        obj[f.feature][0] = f.value;
+      });
+      setCurrent(product);
+    }).then(() => {
+      // push target characteristics into obj
+      target.features.forEach((f) => {
+        if (obj[f.feature] === undefined) obj[f.feature] = ['', ''];
+        obj[f.feature][1] = f.value;
+      });
+      setFeatures(obj);
+    });
+  }, []);
+
+  return (
+    <TableContainer>
+      <table>
+        <thead>
+          <tr>
+            <th>{current.name}</th>
+            <th>Characteristics</th>
+            <th>{target.name}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.keys(features).map((feature) => (
+            <tr key={feature}>
+              <td>{features[feature][0]}</td>
+              <td>{feature}</td>
+              <td>{features[feature][1]}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </TableContainer>
+  );
+}

--- a/src/components/related/api.js
+++ b/src/components/related/api.js
@@ -18,6 +18,7 @@ export function getProductCard(id) {
       name: res.data.name,
       category: res.data.category,
       price: res.data.default_price,
+      features: res.data.features,
     };
   }).then(() => axios.get(`/reviews/meta?product_id=${id}`)).then((res) => {
     // calculate average rating

--- a/src/styles/GlobalStyles.jsx
+++ b/src/styles/GlobalStyles.jsx
@@ -13,6 +13,10 @@ const GlobalStyle = createGlobalStyle`
     margin: 0;
     padding: 0;
   }
+
+  td, th {
+    border: 1px solid black;
+  }
 `;
 
 export default GlobalStyle;

--- a/src/tests/RelatedList.test.js
+++ b/src/tests/RelatedList.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { waitFor } from '@testing-library/dom';
+import '@testing-library/jest-dom';
+import RelatedList from '../components/related/RelatedList.jsx';
+
+describe('Related Items', () => {
+  beforeAll(() => {
+    render(<RelatedList />);
+  });
+
+  it('Renders the list of related items', async () => {
+    // render header
+    expect(screen.getByText('Related Items:')).toBeInTheDocument();
+
+    // 4 images should get rendered
+    await waitFor(() => {
+      expect(screen.getAllByRole('img').length).toEqual(4);
+    });
+  });
+});


### PR DESCRIPTION
When a user clicks the button on a card in the related items list, a modal pops up comparing the current product and clicked product (also small changes to the top header bar so it doesn't create a horizontal scrollbar and is a bit bigger).

Looking forward, this isn't the behavior *every* card component should have when the button gets clicked, only when cards in the related items list get clicked. Since I haven't done much for the outfit list yet, I'll add that as a tech debt ticket.

![image](https://user-images.githubusercontent.com/25358856/205984658-6e80398d-8664-43fc-a027-4427296c0070.png)

