### PR TITLE
Move Redux reducer around

### DIFF
--- a/src/components/related/Card.jsx
+++ b/src/components/related/Card.jsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { useDispatch } from 'react-redux';
 import { getProductCard } from './api.js';
 import useModal from '../shared/useModal.js';
 import Modal from '../shared/Modal.jsx';
 import Table from './Table.jsx';
+import { changeProduct } from '../../store/productReducer.js';
 
 const CardContainer = styled.div`
   position: relative;
@@ -33,6 +35,8 @@ export default function Card({ id, parent }) {
 
   const { visible, toggle } = useModal();
 
+  const dispatch = useDispatch();
+
   // get product info based on the id prop
   useEffect(() => {
     getProductCard(id).then((res) => setProduct(res));
@@ -50,7 +54,8 @@ export default function Card({ id, parent }) {
         <Table currentId={parent} target={product} />
       </Modal>
       <h4>{product.category}</h4>
-      <h3>{product.name}</h3>
+      {/* temp button to demonstrate dispatch */}
+      <h3><button type="button" onClick={() => dispatch(changeProduct(id))}>{product.name}</button></h3>
       <p>
         $
         {product.price}

--- a/src/components/related/RelatedList.jsx
+++ b/src/components/related/RelatedList.jsx
@@ -1,10 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { useSelector, useDispatch } from 'react-redux';
 import { getRelated } from './api.js';
 import Card from './Card.jsx';
 
 const ListContainer = styled.div`
   display: inline-flex;
+  width: 100vw;
+  max-width: 100%;
   overflow: hidden;
   gap: 10px;
 `;
@@ -13,17 +16,19 @@ export default function RelatedList() {
   const [related, setRelated] = useState([]);
   const [outfit, setOutfit] = useState([]);
 
+  const id = useSelector((state) => state.product.productId);
+
   useEffect(() => {
     // get related products for a random product
-    getRelated(37311).then((res) => setRelated(res));
-  }, []);
+    getRelated(id).then((res) => setRelated(res));
+  }, [id]);
 
   return (
     <>
       <div className="related">
         <h1>Related Items:</h1>
         <ListContainer>
-          {related.map((product) => <Card key={product} id={product} parent={37311} />)}
+          {related.map((product) => <Card key={product} id={product} parent={id} />)}
         </ListContainer>
       </div>
       <div className="outfit">

--- a/src/store/productAction.js
+++ b/src/store/productAction.js
@@ -1,5 +1,0 @@
-import { createAction } from '@reduxjs/toolkit';
-
-const changeProduct = createAction('changeBook');
-
-export default changeProduct;

--- a/src/store/productReducer.js
+++ b/src/store/productReducer.js
@@ -1,14 +1,20 @@
-import { createReducer } from '@reduxjs/toolkit';
-import changeProduct from './productAction.js';
+import { createSlice } from '@reduxjs/toolkit';
 
-const initialState = {
-  productId: 37324,
-};
-
-const productReducer = createReducer(initialState, (builder) => {
-  builder.addCase(changeProduct, (state, action) => {
-    initialState.productId = action.payload;
-  });
+// the changeProduct reducer changes the state to a new productId
+const productSlice = createSlice({
+  name: 'product',
+  initialState: {
+    productId: 37324,
+  },
+  reducers: {
+    changeProduct: (state, action) => ({
+      productId: action.payload,
+    }),
+  },
 });
 
-export default productReducer;
+// export function that will be called by dispatch
+export const { changeProduct } = productSlice.actions;
+
+// export reducer to be used by store
+export default productSlice.reducer;


### PR DESCRIPTION
The documentation for Redux in general isn't super great, but we definitely need a way to update our initial state. An example I found used `createSlice` to initiate both the state and reducers. The reducers get passed along to the store like before, and the reducer functions (in this case, just `changeProduct`) are available to import as well. 

To update the state from within a component, we call the `useDispatch` hook which gives us a dispatcher function. We can then call that function with a reducer action as an argument to change the state.