### PR TITLE
Add image carousel within Card component (carousel-ception)

### DIFF
--- a/src/components/related/Card.jsx
+++ b/src/components/related/Card.jsx
@@ -9,11 +9,14 @@ import Stars from '../shared/Stars.jsx';
 import Table from './Table.jsx';
 import { changeProduct, addProduct } from '../../store/productReducer.js';
 import getProduct from '../shared/productAPI.js';
+import ImageCarousel from './ImageCarousel.jsx';
 
 const CardContainer = styled.div`
   background: ${({ theme }) => theme.fg};
   position: relative;
+  overflow: hidden;
   width: 200px;
+  min-width: 200px;
   height: 400px;
   margin: 30px;
   transition: all 0.2s ease-out;
@@ -124,7 +127,7 @@ export default function Card({
         <Modal visible={visible} toggle={toggle}>
           <Table target={product} />
         </Modal>
-        <Img src={product.styles ? product.styles[0].photos[0].thumbnail_url : 'https://media.istockphoto.com/id/1281804798/photo/very-closeup-view-of-amazing-domestic-pet-in-mirror-round-fashion-sunglasses-is-isolated-on.jpg?b=1&s=170667a&w=0&k=20&c=4CLWHzcFeku9olx0np2htie2cOdxWamO-6lJc-Co8Vc='} alt="" />
+        <ImageCarousel images={product.styles ? product.styles[0].photos : [{ thumbnail_url: 'https://media.tenor.com/2roX3uxz_68AAAAM/cat-space.gif' }]} />
         <p>{product.category}</p>
         <h5>{product.name}</h5>
         {product.styles && (product.styles[0].sale_price === null ? (

--- a/src/components/related/Card.jsx
+++ b/src/components/related/Card.jsx
@@ -33,13 +33,6 @@ const CardContainer = styled.div`
   }
 `;
 
-const Img = styled.img`
-  height: 300px;
-  width: 200px;
-  object-fit: cover;
-  border-radius: 10px 10px 0 0;
-`;
-
 const Button = styled.button`
   width: 1.5rem;
   height: 1.5rem;

--- a/src/components/related/ImageCarousel.jsx
+++ b/src/components/related/ImageCarousel.jsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+const ImgContainer = styled.div`
+  height: 300px;
+  width: 200px;
+  background: url(${(props) => props.bg});
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  position: relative;
+  overflow: hidden;
+  transition: all 0.2s ease-out;
+  cursor: pointer;
+
+  &:hover > div {
+    display: inline-flex;
+  }
+`;
+
+const Carousel = styled.div`
+  display: none;
+  margin: 0 20px;
+  position: absolute;
+  bottom: 0px;
+  width: 160px;
+  min-width: 160px;
+`;
+
+const Nav = styled.button`
+  position: absolute;
+  bottom: 10px;
+  left: ${(props) => (props.left ? -20 : 160)}px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  z-index: 1;
+  cursor: pointer;
+`;
+
+const Img = styled.img`
+  width: 40px;
+  min-width: 40px;
+  height: 40px;
+  object-fit: cover;
+  transition: all 0.1s ease-out;
+  transform: translateX(${({ offset }) => -40 * offset}px);
+  cursor: pointer;
+`;
+
+export default function ImageCarousel({ images }) {
+  const [index, setIndex] = useState(0);
+  const [offset, setOffset] = useState(0);
+
+  return (
+    <ImgContainer bg={images[index].thumbnail_url || 'https://media.tenor.com/2roX3uxz_68AAAAM/cat-space.gif'}>
+      {images.length > 1
+      && (
+        <Carousel>
+          <Nav
+            left
+            onClick={(e) => {
+              e.stopPropagation();
+              if (offset > 0) {
+                setOffset(offset - 1);
+              }
+            }}
+          >
+            &lt;
+          </Nav>
+          <Nav
+            onClick={(e) => {
+              e.stopPropagation();
+              if (offset < images.length - 4) {
+                setOffset(offset + 1);
+              }
+            }}
+          >
+            &gt;
+          </Nav>
+
+          {images.map((image, i) => image.thumbnail_url
+          && (
+            <Img
+              key={image.thumbnail_url}
+              src={image.thumbnail_url}
+              offset={offset}
+              onClick={(e) => {
+                e.stopPropagation();
+                setIndex(i);
+              }}
+            />
+          ))}
+        </Carousel>
+      )}
+    </ImgContainer>
+  );
+}

--- a/src/components/related/RelatedList.jsx
+++ b/src/components/related/RelatedList.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 import styled from 'styled-components';
 import { useSelector, useDispatch } from 'react-redux';
-import { getRelated } from './api.js';
+import getRelated from './api.js';
 import Card from './Card.jsx';
 import getProduct from '../shared/productAPI.js';
 import { addToOutfit, removeFromOutfit } from '../../store/productReducer.js';

--- a/src/components/related/api.js
+++ b/src/components/related/api.js
@@ -8,41 +8,8 @@ const axios = require('axios').create({
   headers: { Authorization: config.API_TOKEN },
 });
 
-// GET product info based on ID, return formatted data for use by Card component
-export function getProductCard(id) {
-  // variable to store formatted data
-  let result = {};
-  return axios.get(`/products/${id}`).then((res) => {
-    // store the product name, category, and price
-    result = {
-      name: res.data.name,
-      category: res.data.category,
-      price: res.data.default_price,
-      features: res.data.features,
-    };
-  }).then(() => axios.get(`/reviews/meta?product_id=${id}`)).then((res) => {
-    // calculate average rating
-    const { ratings } = res.data;
-    let total = 0;
-    let average = 0;
-    for (let i = 1; i < 6; i += 1) {
-      if (ratings[i]) {
-        total += parseInt(ratings[i], 10);
-        average += parseInt(ratings[i], 10) * i;
-      }
-    }
-    // format rating, handle case where there are no ratings
-    result.rating = total ? (average / total).toFixed(2) : null;
-  })
-    .then(() => axios.get(`/products/${id}/styles`))
-    .then((res) => ({
-      ...result,
-      image: res.data.results[0].photos[0].thumbnail_url,
-    }));
-}
-
 // GET related products given an ID
-export function getRelated(id) {
+export default function getRelated(id) {
   // a set is used to make sure the related products are all unique
   return axios.get(`/products/${id}/related`).then((res) => [...new Set(res.data)]);
 }

--- a/src/components/related/api.js
+++ b/src/components/related/api.js
@@ -43,5 +43,6 @@ export function getProductCard(id) {
 
 // GET related products given an ID
 export function getRelated(id) {
-  return axios.get(`/products/${id}/related`).then((res) => res.data);
+  // a set is used to make sure the related products are all unique
+  return axios.get(`/products/${id}/related`).then((res) => [...new Set(res.data)]);
 }

--- a/src/store/productReducer.js
+++ b/src/store/productReducer.js
@@ -5,7 +5,7 @@ import { createSlice } from '@reduxjs/toolkit';
 const productSlice = createSlice({
   name: 'product',
   initialState: {
-    productId: 37324,
+    productId: 37313,
     productData: {},
     products: {},
     outfit: [],


### PR DESCRIPTION
When a user hovers over an image within a card, a carousel appears displaying other images associated with that product's default style. The user can scroll through those images and select an image to be displayed on the card by clicking the thumbnail image. The user can still click on the main image and navigate to that given product. There are still a few bugs for me to work out, but the main functionality is there.

![image](https://user-images.githubusercontent.com/25358856/207154002-c5debdfe-deb8-4ff2-b1df-38fda3b37a06.png)
